### PR TITLE
Improve error handling and presentation

### DIFF
--- a/src/com/Upwork/api/OAuthClient.java
+++ b/src/com/Upwork/api/OAuthClient.java
@@ -20,10 +20,7 @@ package com.Upwork.api;
 
 import com.Upwork.ClassPreamble;
 import com.google.api.client.auth.oauth2.*;
-import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpRequestFactory;
-import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.*;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.http.json.JsonHttpContent;
 import com.google.api.client.json.JsonFactory;
@@ -61,7 +58,7 @@ public class OAuthClient {
     /** Global instance of the HTTP transport. */
     private static final HttpTransport HTTP_TRANSPORT = new NetHttpTransport();
     private static final JsonFactory JSON_FACTORY = new JacksonFactory();
-    private static final HttpRequestFactory HTTP_REQUEST_FACTORY = HTTP_TRANSPORT.createRequestFactory();
+    private static HttpRequestFactory HTTP_REQUEST_FACTORY = HTTP_TRANSPORT.createRequestFactory();
 
 	private static String clientId		= null;
 	private static String clientSecret	= null;
@@ -341,5 +338,9 @@ public class OAuthClient {
 	private final String getFullUrl(String url) {
 		return UPWORK_BASE_URL + entryPoint + url + 
 			((entryPoint == "api") ? ("." + DATA_FORMAT) : "");
+	}
+
+	public static void setRequestInitializer(final HttpRequestInitializer newInitializer) {
+		HTTP_REQUEST_FACTORY = HTTP_TRANSPORT.createRequestFactory(newInitializer);
 	}
 }

--- a/src/com/Upwork/api/UpworkRestClient.java
+++ b/src/com/Upwork/api/UpworkRestClient.java
@@ -19,6 +19,7 @@
 package com.Upwork.api;
 
 import com.Upwork.ClassPreamble;
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import org.json.JSONException;
@@ -49,6 +50,9 @@ public class UpworkRestClient {
         HttpResponse response = null;
 
         try {
+            // No matter what, do not throw for non 2xx responses
+            request.setThrowExceptionOnExecuteError(false);
+            // Process the request normally
             response = request.execute();
             if(response.getStatusCode() == 200) {
                 if (response.getContent() != null) {
@@ -108,8 +112,9 @@ public class UpworkRestClient {
      * @return  {@link JSONObject}
      * */
     private static JSONObject genError(HttpResponse response) throws JSONException {
-    	String code		= (String) response.getHeaders().get("X-Upwork-Error-Code");
-    	String message	= (String) response.getHeaders().get("X-Upwork-Error-Message");
+        final HttpHeaders headers = response.getHeaders();
+        String code = headers.getFirstHeaderStringValue("X-Upwork-Error-Code");
+        String message = headers.getFirstHeaderStringValue("X-Upwork-Error-Message");
     	
     	if (code == null) {
     		code = Integer.toString(response.getStatusCode());


### PR DESCRIPTION
These changes address the scenarios where:-

1.  The request throws and IOException due to a read timeout. i.e. The response from the server took 20 seconds (the default timeout).
2. The server response with a non 2xx header and the request throws a HttpResponseException. The exception thrown is an extension of the IOException class and results in the details getting lost.

The changes to OAuthClient.java allows a custom initializer to be set by external classes, which in turn can specify a custom timeout.

The changes toUpworkRestClient.java are to change the non 2xx behaviour on the request and correct a cast error that was thrown whenever genError(HttpResponse response) was called.